### PR TITLE
Authn session expiration

### DIFF
--- a/lib/samlp.js
+++ b/lib/samlp.js
@@ -40,22 +40,23 @@ function getSamlResponse(options, user, callback) {
   }
 
   saml20.create({
-    signatureAlgorithm:   options.signatureAlgorithm,
-    digestAlgorithm:      options.digestAlgorithm,
-    cert:                 options.cert,
-    key:                  options.key,
-    issuer:               options.issuer,
-    lifetimeInSeconds:    options.lifetimeInSeconds || 3600,
-    audiences:            options.audience,
-    attributes:           claims,
-    nameIdentifier:       ni.nameIdentifier,
-    nameIdentifierFormat: ni.nameIdentifierFormat || options.nameIdentifierFormat,
-    recipient:            options.recipient,
-    inResponseTo:         options.inResponseTo,
-    authnContextClassRef: options.authnContextClassRef,
-    encryptionPublicKey:  options.encryptionPublicKey,
-    encryptionCert:       options.encryptionCert,
-    timeStampFormat:      options.timeStampFormat || 'YYYY-MM-DDTHH:mm:ss.SSS[Z]'
+    signatureAlgorithm:       options.signatureAlgorithm,
+    digestAlgorithm:          options.digestAlgorithm,
+    cert:                     options.cert,
+    key:                      options.key,
+    issuer:                   options.issuer,
+    lifetimeInSeconds:        options.lifetimeInSeconds || 3600,
+    sessionLifetimeInSeconds: options.sessionLifetimeInSeconds,
+    audiences:                options.audience,
+    attributes:               claims,
+    nameIdentifier:           ni.nameIdentifier,
+    nameIdentifierFormat:     ni.nameIdentifierFormat || options.nameIdentifierFormat,
+    recipient:                options.recipient,
+    inResponseTo:             options.inResponseTo,
+    authnContextClassRef:     options.authnContextClassRef,
+    encryptionPublicKey:      options.encryptionPublicKey,
+    encryptionCert:           options.encryptionCert,
+    timeStampFormat:          options.timeStampFormat || 'YYYY-MM-DDTHH:mm:ss.SSS[Z]'
   }, function (err, signedAssertion) {
     if (err) return callback(err);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "samlp",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "SAML Protocol server middleware",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
We need support for `SessionNotOnOrAfter` on the `AuthnStatement` element.
This option pass-through is for `node-samlp`.

Details:
http://stackoverflow.com/questions/29508906/notonorafter-in-subjectconfirmationdata-and-conditions-and-sessionnotonorafter
